### PR TITLE
Fix a misspelled class name

### DIFF
--- a/lib/exclamation/error.rb
+++ b/lib/exclamation/error.rb
@@ -1,5 +1,5 @@
 module Exclamation
-  class ConfiguratoinFileNotFound < RuntimeError
+  class ConfigurationFileNotFound < RuntimeError
     def initialize(message='Uh oh! Looks like your config filepath is incorrect.')
       super(message)
     end


### PR DESCRIPTION
In order to ensure that the error class is properly declared based on
how it is used, this commit fixes a small spelling error.
